### PR TITLE
Move to C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 project(Verlet)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 # Set output directories for binaries

--- a/src/verlet_lib/code/public/verlet/gui/app_gui.hpp
+++ b/src/verlet_lib/code/public/verlet/gui/app_gui.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iterator>
 #include <string_view>
 
 #include "fmt/core.h"

--- a/yae_project.json
+++ b/yae_project.json
@@ -19,6 +19,6 @@
         }
     },
     "cpp": {
-        "standard": "20"
+        "standard": "23"
     }
 }


### PR DESCRIPTION
Moves with edt, whose `Matrix` no longer carries a C++20 fallback.

`app_gui.hpp` needs an explicit `<iterator>`; libc++ no longer provides it transitively at this standard.

Requires Sunday111/edt#5 and Sunday111/klvk#9.