### PR TITLE
Test ObjectPool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,11 +55,6 @@ add_subdirectory(${YAE_refl_SOURCES} yae_modules/Sunday111/refl/main/modules/ref
 set(YAE_cpptrace_SOURCES ${YAE_CLONED_REPOSITORIES_DIR}/jeremy-rifkin/cpptrace/main)
 add_subdirectory(${YAE_cpptrace_SOURCES} yae_modules/jeremy-rifkin/cpptrace/main SYSTEM)
 
-# https://github.com/TartanLlama/expected v1.1.0
-set(YAE_expected_SOURCES ${YAE_CLONED_REPOSITORIES_DIR}/TartanLlama/expected/v1.1.0)
-option(EXPECTED_BUILD_TESTS "" OFF)
-add_subdirectory(${YAE_expected_SOURCES} yae_modules/TartanLlama/expected/v1.1.0 SYSTEM)
-
 # https://github.com/Neargye/magic_enum v0.9.7
 set(YAE_magic_enum_SOURCES ${YAE_CLONED_REPOSITORIES_DIR}/Neargye/magic_enum/v0.9.7)
 add_subdirectory(${YAE_magic_enum_SOURCES} yae_modules/Neargye/magic_enum/v0.9.7 SYSTEM)
@@ -118,6 +113,15 @@ add_subdirectory(${YAE_verlet_lib_SOURCES} yae_modules/src/verlet_lib SYSTEM)
 set(YAE_verlet_SOURCES src/verlet)
 add_subdirectory(${YAE_verlet_SOURCES} yae_modules/src/verlet SYSTEM)
 
+# https://github.com/google/googletest v1.15.2
+set(YAE_gtest_main_SOURCES ${YAE_CLONED_REPOSITORIES_DIR}/google/googletest/v1.15.2)
+option(INSTALL_GTEST "" OFF)
+option(BUILD_GMOCK "" OFF)
+add_subdirectory(${YAE_gtest_main_SOURCES} yae_modules/google/googletest/v1.15.2 SYSTEM)
+
+set(YAE_verlet_tests_SOURCES src/verlet_tests)
+add_subdirectory(${YAE_verlet_tests_SOURCES} yae_modules/src/verlet_tests SYSTEM)
+
 set(YAE_verlet_video_SOURCES src/verlet_video)
 add_subdirectory(${YAE_verlet_video_SOURCES} yae_modules/src/verlet_video SYSTEM)
 
@@ -128,12 +132,6 @@ option(BENCHMARK_ENABLE_TESTING "" OFF)
 add_subdirectory(${YAE_gbench_SOURCES} yae_modules/google/benchmark/v1.9.4 SYSTEM)
 
 include(${YAE_CLONED_REPOSITORIES_DIR}/Sunday111/yae-support/main/modules/third_party/gbench.module.cmake)
-# https://github.com/google/googletest v1.15.2
-set(YAE_gtest_SOURCES ${YAE_CLONED_REPOSITORIES_DIR}/google/googletest/v1.15.2)
-option(INSTALL_GTEST "" OFF)
-option(BUILD_GMOCK "" OFF)
-add_subdirectory(${YAE_gtest_SOURCES} yae_modules/google/googletest/v1.15.2 SYSTEM)
-
 set(YAE_yae_example_benchmark_SOURCES ${YAE_CLONED_REPOSITORIES_DIR}/Sunday111/yae-support/main/modules/examples/yae_example_benchmark)
 add_subdirectory(${YAE_yae_example_benchmark_SOURCES} yae_modules/Sunday111/yae-support/main/modules/examples/yae_example_benchmark SYSTEM)
 

--- a/src/verlet_tests/CMakeLists.txt
+++ b/src/verlet_tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.20)
+include(set_compiler_options)
+set(module_source_files
+    ${CMAKE_CURRENT_SOURCE_DIR}/code/private/object_pool.cpp)
+add_executable(verlet_tests ${module_source_files})
+set_generic_compiler_options(verlet_tests PRIVATE)
+target_link_libraries(verlet_tests PRIVATE verlet_lib
+                                           gtest_main)
+target_include_directories(verlet_tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/code/public)
+target_include_directories(verlet_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/code/private)
+enable_testing()
+include(GoogleTest)
+gtest_discover_tests(verlet_tests)

--- a/src/verlet_tests/code/private/object_pool.cpp
+++ b/src/verlet_tests/code/private/object_pool.cpp
@@ -1,0 +1,109 @@
+#include "verlet/object_pool.hpp"
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace
+{
+std::vector<verlet::ObjectId> Identifiers(const verlet::ObjectPool& pool)
+{
+    std::vector<verlet::ObjectId> ids;
+    for (const verlet::ObjectId id : pool.Identifiers()) ids.push_back(id);
+    return ids;
+}
+}  // namespace
+
+TEST(ObjectPoolTest, StartsEmpty)  // NOLINT
+{
+    const verlet::ObjectPool pool;
+    EXPECT_EQ(pool.ObjectsCount(), 0U);
+    EXPECT_TRUE(Identifiers(pool).empty());
+}
+
+TEST(ObjectPoolTest, AllocReportsTheObject)  // NOLINT
+{
+    verlet::ObjectPool pool;
+    const auto [id, object] = pool.Alloc();
+
+    EXPECT_EQ(pool.ObjectsCount(), 1U);
+    EXPECT_EQ(Identifiers(pool), std::vector{id});
+}
+
+TEST(ObjectPoolTest, AllocatedObjectsAreDistinct)  // NOLINT
+{
+    verlet::ObjectPool pool;
+    const auto [a, object_a] = pool.Alloc();
+    const auto [b, object_b] = pool.Alloc();
+
+    EXPECT_NE(a, b);
+    EXPECT_EQ(pool.ObjectsCount(), 2U);
+    EXPECT_EQ(Identifiers(pool).size(), 2U);
+}
+
+// Writing through the reference Alloc returned has to be visible through the pool.
+TEST(ObjectPoolTest, KeepsWhatWasWrittenThroughTheReference)  // NOLINT
+{
+    verlet::ObjectPool pool;
+    const auto [id, object] = pool.Alloc();
+    object.position = {3.f, 4.f};
+    object.movable = true;
+
+    const verlet::VerletObject& stored = pool.Get(id);
+    EXPECT_EQ(stored.position.x(), 3.f);
+    EXPECT_EQ(stored.position.y(), 4.f);
+    EXPECT_TRUE(stored.IsMovable());
+}
+
+TEST(ObjectPoolTest, FreeDropsTheObject)  // NOLINT
+{
+    verlet::ObjectPool pool;
+    const auto [kept, kept_object] = pool.Alloc();
+    const auto [dropped, dropped_object] = pool.Alloc();
+
+    pool.Free(dropped);
+
+    EXPECT_EQ(pool.ObjectsCount(), 1U);
+    EXPECT_EQ(Identifiers(pool), std::vector{kept});
+}
+
+// A freed slot goes on the free list, so the next allocation takes it back rather than
+// growing the pool.
+TEST(ObjectPoolTest, ReusesAFreedSlot)  // NOLINT
+{
+    verlet::ObjectPool pool;
+    const auto [first, first_object] = pool.Alloc();
+    pool.Free(first);
+
+    const auto [second, second_object] = pool.Alloc();
+
+    EXPECT_EQ(second, first);
+    EXPECT_EQ(pool.ObjectsCount(), 1U);
+}
+
+TEST(ObjectPoolTest, ClearRemovesEverything)  // NOLINT
+{
+    verlet::ObjectPool pool;
+    for (size_t i = 0; i != 8; ++i) [[maybe_unused]] const auto entry = pool.Alloc();
+
+    pool.Clear();
+
+    EXPECT_EQ(pool.ObjectsCount(), 0U);
+    EXPECT_TRUE(Identifiers(pool).empty());
+}
+
+// Clearing a pool with holes in it must not trip over the free slots.
+TEST(ObjectPoolTest, ClearsAPoolWithHoles)  // NOLINT
+{
+    verlet::ObjectPool pool;
+    std::vector<verlet::ObjectId> ids;
+    for (size_t i = 0; i != 6; ++i) ids.push_back(std::get<0>(pool.Alloc()));
+
+    pool.Free(ids[1]);
+    pool.Free(ids[4]);
+    ASSERT_EQ(pool.ObjectsCount(), 4U);
+
+    pool.Clear();
+    EXPECT_EQ(pool.ObjectsCount(), 0U);
+    EXPECT_TRUE(Identifiers(pool).empty());
+}

--- a/src/verlet_tests/verlet_tests.module.json
+++ b/src/verlet_tests/verlet_tests.module.json
@@ -1,0 +1,11 @@
+{
+    "ModuleType": "Executable",
+    "EnableTesting": true,
+    "Dependencies": {
+        "Public": [],
+        "Private": [
+            "verlet_lib",
+            "gtest_main"
+        ]
+    }
+}


### PR DESCRIPTION
First tests in this repo and somewhere to add more. Covers allocation, identifiers, freeing, free-slot reuse and clearing a pool with holes in it. 8 tests, no window or device needed.

No CI here yet: CMake configures the whole project whatever target you ask for, so any test target pulls klvk in and the runner would need ffmpeg, shaderc, X11 and Wayland just to configure.